### PR TITLE
Implement BOUND for other encodings as well

### DIFF
--- a/bench/benches/bsbm_explore.rs
+++ b/bench/benches/bsbm_explore.rs
@@ -9,7 +9,7 @@ use codspeed_criterion_compat::{Criterion, criterion_group, criterion_main};
 use futures::StreamExt;
 use rdf_fusion::io::RdfFormat;
 use rdf_fusion::store::Store;
-use rdf_fusion::{OptimizationLevel, QueryOptions, QueryResults};
+use rdf_fusion::{QueryOptions, QueryResults};
 use std::fs;
 use std::path::PathBuf;
 use tokio::runtime::{Builder, Runtime};

--- a/lib/functions/src/scalar/functional_form/bound.rs
+++ b/lib/functions/src/scalar/functional_form/bound.rs
@@ -1,12 +1,17 @@
-use crate::scalar::dispatch::dispatch_unary_typed_value;
-use crate::scalar::sparql_op_impl::{SparqlOpImpl, create_typed_value_sparql_op_impl};
+use crate::scalar::sparql_op_impl::{ClosureSparqlOpImpl, SparqlOpImpl};
 use crate::scalar::{ScalarSparqlOp, UnaryArgs};
-use datafusion::logical_expr::Volatility;
+use datafusion::arrow::array::Array;
+use datafusion::arrow::compute::is_not_null;
+use datafusion::logical_expr::{ColumnarValue, Volatility};
 use rdf_fusion_api::functions::BuiltinName;
 use rdf_fusion_api::functions::FunctionName;
-use rdf_fusion_encoding::TermEncoding;
-use rdf_fusion_encoding::typed_value::TypedValueEncoding;
-use rdf_fusion_model::TypedValueRef;
+use rdf_fusion_common::DFResult;
+use rdf_fusion_encoding::object_id::ObjectIdEncoding;
+use rdf_fusion_encoding::plain_term::PlainTermEncoding;
+use rdf_fusion_encoding::typed_value::{
+    TYPED_VALUE_ENCODING, TypedValueArray, TypedValueArrayBuilder, TypedValueEncoding,
+};
+use rdf_fusion_encoding::{EncodingArray, EncodingDatum, EncodingScalar, TermEncoding};
 
 #[derive(Debug)]
 pub struct BoundSparqlOp;
@@ -36,15 +41,97 @@ impl ScalarSparqlOp for BoundSparqlOp {
         Volatility::Immutable
     }
 
+    fn plain_term_encoding_op(
+        &self,
+    ) -> Option<Box<dyn SparqlOpImpl<Self::Args<PlainTermEncoding>>>> {
+        Some(Box::new(
+            ClosureSparqlOpImpl::<UnaryArgs<PlainTermEncoding>>::new(
+                TYPED_VALUE_ENCODING.data_type(),
+                Box::new(|UnaryArgs(args)| impl_bound_plain_term(&args)),
+            ),
+        ))
+    }
+
     fn typed_value_encoding_op(
         &self,
     ) -> Option<Box<dyn SparqlOpImpl<Self::Args<TypedValueEncoding>>>> {
-        Some(create_typed_value_sparql_op_impl(|UnaryArgs(arg)| {
-            dispatch_unary_typed_value(
-                &arg,
-                |_| Ok(TypedValueRef::BooleanLiteral(true.into())),
-                || Ok(TypedValueRef::BooleanLiteral(false.into())),
-            )
-        }))
+        Some(Box::new(
+            ClosureSparqlOpImpl::<UnaryArgs<TypedValueEncoding>>::new(
+                TYPED_VALUE_ENCODING.data_type(),
+                Box::new(|UnaryArgs(args)| impl_bound_typed_value(&args)),
+            ),
+        ))
     }
+
+    fn object_id_encoding_op(
+        &self,
+    ) -> Option<Box<dyn SparqlOpImpl<Self::Args<ObjectIdEncoding>>>> {
+        Some(Box::new(
+            ClosureSparqlOpImpl::<UnaryArgs<ObjectIdEncoding>>::new(
+                TYPED_VALUE_ENCODING.data_type(),
+                Box::new(|UnaryArgs(args)| impl_bound_object_id(&args)),
+            ),
+        ))
+    }
+}
+
+fn impl_bound_plain_term(
+    array: &EncodingDatum<PlainTermEncoding>,
+) -> DFResult<ColumnarValue> {
+    match array {
+        EncodingDatum::Array(array) => impl_bound_array(array.array().as_ref())
+            .map(|array| ColumnarValue::Array(array.into_array())),
+        EncodingDatum::Scalar(scalar, _) => {
+            let array = scalar.to_array(1)?.into_array();
+            impl_bound_array(array.as_ref())?
+                .try_as_scalar(0)
+                .map(|scalar| ColumnarValue::Scalar(scalar.into_scalar_value()))
+        }
+    }
+}
+
+fn impl_bound_typed_value(
+    array: &EncodingDatum<TypedValueEncoding>,
+) -> DFResult<ColumnarValue> {
+    match array {
+        EncodingDatum::Array(array) => impl_bound_array(array.array().as_ref())
+            .map(|array| ColumnarValue::Array(array.into_array())),
+        EncodingDatum::Scalar(scalar, _) => {
+            let array = scalar.to_array(1)?.into_array();
+            impl_bound_array(array.as_ref())?
+                .try_as_scalar(0)
+                .map(|scalar| ColumnarValue::Scalar(scalar.into_scalar_value()))
+        }
+    }
+}
+
+fn impl_bound_object_id(
+    array: &EncodingDatum<ObjectIdEncoding>,
+) -> DFResult<ColumnarValue> {
+    match array {
+        EncodingDatum::Array(array) => impl_bound_array(array.array().as_ref())
+            .map(|array| ColumnarValue::Array(array.into_array())),
+        EncodingDatum::Scalar(scalar, _) => {
+            let array = scalar.to_array(1)?.into_array();
+            impl_bound_array(array.as_ref())?
+                .try_as_scalar(0)
+                .map(|scalar| ColumnarValue::Scalar(scalar.into_scalar_value()))
+        }
+    }
+}
+
+fn impl_bound_array(array: &dyn Array) -> DFResult<TypedValueArray> {
+    let result = is_not_null(array)?;
+    assert_eq!(
+        result.null_count(),
+        0,
+        "is_not_null should never return null"
+    );
+
+    let mut builder = TypedValueArrayBuilder::default();
+    for value in result.values() {
+        builder.append_boolean(value.into())?;
+    }
+
+    TYPED_VALUE_ENCODING.try_new_array(builder.finish())
 }

--- a/lib/functions/src/scalar/sparql_op_impl.rs
+++ b/lib/functions/src/scalar/sparql_op_impl.rs
@@ -19,6 +19,19 @@ pub struct ClosureSparqlOpImpl<Args> {
     closure: Box<dyn Fn(Args) -> DFResult<ColumnarValue>>,
 }
 
+impl<Args> ClosureSparqlOpImpl<Args> {
+    /// Create a new `ClosureSparqlOpImpl`.
+    pub fn new(
+        return_type: DataType,
+        closure: impl Fn(Args) -> DFResult<ColumnarValue> + 'static,
+    ) -> Self {
+        Self {
+            return_type,
+            closure: Box::new(closure),
+        }
+    }
+}
+
 impl<Args> SparqlOpImpl<Args> for ClosureSparqlOpImpl<Args> {
     fn return_type(&self) -> DataType {
         self.return_type.clone()


### PR DESCRIPTION
Evaluating bound should be possible for any encoding as it is basically a NULL check. This is to avoid expensive encoding transformations.