### PR TITLE
Force Single Threaded Execution in CodSpeed

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v3
+        env:
+          RDF_FUSION_SINGLE_THREAD_BENCH: "true"
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: cargo codspeed run

--- a/bench/benches/utils/mod.rs
+++ b/bench/benches/utils/mod.rs
@@ -31,7 +31,9 @@ pub async fn consume_results(result: QueryResults) -> anyhow::Result<usize> {
 }
 
 pub fn create_runtime(target_partitions: usize) -> Runtime {
-    if target_partitions == 1 {
+    let force_single_thred =
+        std::env::var("RDF_FUSION_SINGLE_THREAD_BENCH") == Ok("true".to_string());
+    if target_partitions == 1 || force_single_thred {
         Builder::new_current_thread().enable_all().build().unwrap()
     } else {
         Builder::new_multi_thread()


### PR DESCRIPTION
Forces single-threaded execution in Codspeed to avoid sys calls that mess with CodSpeed's instrumentation